### PR TITLE
Fix Makefile object names for targets: gfortran, intel-seq

### DIFF
--- a/src/Makefile.gfortran
+++ b/src/Makefile.gfortran
@@ -24,8 +24,8 @@ libs = -L/usr/lib/ -llapack -lblas
 # libs = -L/${MKLROOT}/lib/intel64 -lmkl_core -lmkl_sequential -lmkl_intel_lp64 -lpthread
  
  
-main :  $(obj)
-	$(f90) $(obj) -o wt.x $(libs) 
+main :  $(OBJ)
+	$(f90) $(OBJ) -o wt.x $(libs) 
 	cp -f wt.x ../bin
 
 .SUFFIXES: .o .f90

--- a/src/Makefile.intel-seq
+++ b/src/Makefile.intel-seq
@@ -23,8 +23,8 @@ libs = -L/opt/intel/mkl/lib/ \
 		-lmkl_intel_lp64 -lmkl_sequential \
 		-lmkl_core -liomp5
  
-main :  $(obj)
-	$(f90) $(obj) -o wt.x $(libs) 
+main :  $(OBJ)
+	$(f90) $(OBJ) -o wt.x $(libs) 
 	cp -f wt.x ../bin
 
 .SUFFIXES: .o .f90


### PR DESCRIPTION
In compiling (initially for Windows and subsequently for Ubuntu with the gfortran toolchain) I ran into this issue where compilation fails because `make` is treating the targets in a case sensitive way.

I've updated the Makefiles for all targets so they refer to the $(OBJ) with the same case (all caps) as the designated target.

For others in the future, this manifested as an error in the linker because no object files were being built:

`gfortran in function _start' (.text+0x20) undefined reference to main'`