### PR TITLE
fixed some typo bugs in output

### DIFF
--- a/src/ek_bulk.f90
+++ b/src/ek_bulk.f90
@@ -114,8 +114,8 @@ subroutine ek_bulk_line
          outfileindex= outfileindex+ 1
          open(unit=outfileindex, file=filename)
          write(outfileindex, '(a, a6, a, a6)')'# segment between', k3line_name(il), ' and ',  k3line_name(il+1)
-         write(outfileindex, '(a, 3f10.6)')'# kstart (fractional units)', k3line_start(:, il)*Angstrom2atomic
-         write(outfileindex, '(a, 3f10.6)')'# kend   (fractional units)', k3line_end(:, il)*Angstrom2atomic
+         write(outfileindex, '(a, 3f10.6)')'# kstart (fractional units)', k3line_start(:, il)!*Angstrom2atomic   !fractional units
+         write(outfileindex, '(a, 3f10.6)')'# kend   (fractional units)', k3line_end(:, il)!*Angstrom2atomic
    
          do i=1, Num_wann
             do ik=1+(il-1)*Nk1, il*Nk1

--- a/src/readinput.f90
+++ b/src/readinput.f90
@@ -1646,9 +1646,9 @@ subroutine readinput
    if (cpuid.eq.0) then
       write(stdout, *)" "
       write(stdout, *)"The rotated new unit cell in cartesian coordinates : "
-      write(stdout, '(3f12.6)') R1
-      write(stdout, '(3f12.6)') R2
-      write(stdout, '(3f12.6)') R3
+      write(stdout, '(3f12.6)') R1/Angstrom2atomic ! in unit of Angstrom
+      write(stdout, '(3f12.6)') R2/Angstrom2atomic
+      write(stdout, '(3f12.6)') R3/Angstrom2atomic
 
       call get_volume(R1, R2, R3, cell_volume2)
       write(stdout, '(a, f18.5, a)')"New cell's Volume is ", cell_volume2/(Angstrom2atomic**3), 'Ang^3'


### PR DESCRIPTION
1. fixed a bug in ek_bulk.f90 where the output files bulkek.dat_X-X were incorrectly displaying the  k-points in fractional unit
2. fixed a bug in readinput.f90 where the output of the rotated new unit cell was given in atomic units instead of Angstroms in Cartesian coordinates.